### PR TITLE
fix: prevent error on nextjs startup

### DIFF
--- a/bugpilot-next/src/Bugpilot.mjs
+++ b/bugpilot-next/src/Bugpilot.mjs
@@ -10,7 +10,7 @@ import React, {
 import logger from "./logger.mjs";
 import { waitUntilBugpilotAvailable } from "./utils.mjs";
 
-import packageJson from "../package.json";
+import packageJson from "../package.json" assert { type: "json" };
 
 const BUGPILOT_HOST = "https://script.bugpilot.io";
 const BUGPILOT_SCRIPT_FILENAME = "adopto.js";


### PR DESCRIPTION

I've fixed it adding in Bugpilot.mjs:

`import packageJson from "../package.json" assert { type: "json" };`

as described here:
https://stackoverflow.com/questions/70106880/err-import-assertion-type-missing-for-import-of-json-file